### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/scripts/hardhat-tasks-functions.js
+++ b/scripts/hardhat-tasks-functions.js
@@ -228,7 +228,7 @@ async function verifyContract(contractAddress, contractName) {
     }
 
     const tx = await axios.post(url, params, config);
-    console.log(`Check how verification is going at ${demo} with API key ${apiKey} and receipt GUID ${tx.data.result}`);
+    console.log(`Check how verification is going at ${demo} with receipt GUID ${tx.data.result}`);
 }
 
 async function flatten(filePath) {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/2](https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/2)

To fix the problem, we should avoid logging the API key in clear text. The log message on line 231 should be modified to either omit the API key entirely or, if necessary, mask it (e.g., only show the last 4 characters). The best practice is to not log the API key at all. Only the demo URL and receipt GUID should be logged, as these are not sensitive. The change should be made in the `verifyContract` function in `scripts/hardhat-tasks-functions.js`, specifically on line 231. No additional imports or methods are required unless you choose to mask the API key, in which case a simple string manipulation can be used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Eliminate API key from console.log output in verifyContract, logging only the demo URL and receipt GUID