### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/scripts/hardhat-tasks-functions.js
+++ b/scripts/hardhat-tasks-functions.js
@@ -430,7 +430,7 @@ async function verifyContract(contractAddress, contractName) {
     const demoUrl = `https://${hre.network.config.blockExplorer}/sourcecode-demo.html`;
 
     console.log(
-        `Check how verification is going at ${demoUrl} with API key ${apiKey} and receipt GUID ${tx.data.result}`,
+        `Check how verification is going at ${demoUrl} using your API key and receipt GUID ${tx.data.result}`,
     );
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/8](https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/8)

In general, to fix clear-text logging of sensitive information, you either stop logging the sensitive value or replace it with a redacted/masked representation that cannot be used to authenticate. For API keys, the best practice is to not log them at all; if you truly need to correlate logs with a particular key, you can log only an irreversible or partial representation (e.g., last 4 characters) while avoiding exposing the full secret.

For this specific instance in `scripts/hardhat-tasks-functions.js`, the minimal, non-functional change is to modify the `console.log` at line 432–434 so that it no longer includes `${apiKey}`. The rest of the message (demo URL and GUID) is safe to keep. If we still want a hint that an API key is involved, we can include a static placeholder like `[REDACTED]` instead of the actual key, or simply remove mention of the API key and tell the user to use “your API key” generically. No additional imports or helper functions are needed; only the log message string needs to be updated.

Concretely:
- Locate the `console.log` that currently logs `demoUrl`, `apiKey`, and `tx.data.result`.
- Replace it with a message that omits `apiKey` entirely (or uses a literal placeholder) while still providing the GUID and URL.
- Do not change how `apiKey` is used elsewhere for the verification request. Only the logging must change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Redact the API key from the verification status console message while preserving useful context like URL and GUID.