### PR TITLE
Potential fix for code scanning alert no. 6: Regular expression injection

### DIFF
--- a/cmd/generate-cli.js
+++ b/cmd/generate-cli.js
@@ -7,6 +7,11 @@ const { readFileSync, writeFileSync, existsSync, statSync, mkdirSync, readdirSyn
 const { join, basename, relative, sep, dirname } = require('path');
 const { getNameId } = require('../test/utils/utils');
 
+// Escape special characters in a string so it can be safely used in a RegExp pattern
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  __    __   _______  __      .______    _______ .______          _______.
 |  |  |  | |   ____||  |     |   _  \  |   ____||   _  \        /       |
@@ -815,8 +820,9 @@ const findSdkActionSignatureFromTemplateFile = (actionName) => {
         // Convert action name to camelCase for matching
         const camelCaseName = actionName[0].toLowerCase() + actionName.slice(1);
         // Look for the signature block
+        const safeCamelCaseName = escapeRegExp(camelCaseName);
         const regex = new RegExp(
-            `const ${camelCaseName}Action = new dfs\\.actions\\.[\\w.]+\\([\\s\\S]+?\\);`,
+            `const ${safeCamelCaseName}Action = new dfs\\.actions\\.[\\w.]+\\([\\s\\S]+?\\);`,
             'g',
         );
         const match = signatures.match(regex);


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/6](https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/6)

In general, to fix regex injection, any user‑controlled string that is interpolated into a regex pattern must be escaped so that it is treated as literal text, not regex syntax. In Node.js/JavaScript, this is typically done either by using a small helper that replaces all regex metacharacters with escaped versions, or by using a well‑known library function such as `_.escapeRegExp` from lodash.

For this specific case, the only problematic usage is in `cmd/generate-cli.js` inside `findSdkActionSignatureFromTemplateFile`. We should escape `camelCaseName` before inserting it into the pattern. To avoid adding a new dependency, we can define a small local helper, e.g. `escapeRegExp`, near the top of `cmd/generate-cli.js`, and then use it when building the regex:

```js
const safeCamelCaseName = escapeRegExp(camelCaseName);
const regex = new RegExp(
    `const ${safeCamelCaseName}Action = new dfs\\.actions\\.[\\w.]+\\([\\s\\S]+?\\);`,
    'g',
);
```

The helper can be a standard implementation:

```js
function escapeRegExp(string) {
    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
}
```

This change preserves functionality when `actionName` is a normal contract name, but prevents special characters from altering the regex. No other files need changes, and no imports are required because this is pure JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Add a local helper to escape special characters in action names before interpolating them into regular expressions used by the CLI generator.