### PR TITLE
Potential fix for code scanning alert no. 7: Regular expression injection

### DIFF
--- a/cmd/generate-cli.js
+++ b/cmd/generate-cli.js
@@ -1144,9 +1144,11 @@ const findSdkTriggerSignaturesFromTemplateFile = (triggerName) => {
         const signatures = readFileSync(signaturesPath, 'utf8');
         // Convert trigger name to camelCase for matching
         const camelCaseName = triggerName[0].toLowerCase() + triggerName.slice(1);
+        // Escape any special regex characters in the trigger name
+        const safeCamelCaseName = escapeRegExp(camelCaseName);
         // Look for the signature block
         const regex = new RegExp(
-            `const ${camelCaseName} = new dfs\\.triggers\\.[\\w.]+\\([\\s\\S]+?\\);`,
+            `const ${safeCamelCaseName} = new dfs\\.triggers\\.[\\w.]+\\([\\s\\S]+?\\);`,
             'g',
         );
         const match = signatures.match(regex);


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/7](https://github.com/Dargon789/defisaver-v3-contracts/security/code-scanning/7)

In general, the way to fix this issue is to ensure that any user-controlled string that is embedded into a regular expression pattern is first passed through a sanitization/escaping function that escapes all regex metacharacters, or alternatively to constrain it via strict validation to a safe character set and reject anything else. This prevents malicious input from changing the structure or complexity of the regex.

For this specific case, the best fix with minimal functional change is:

- Use the existing `escapeRegExp` helper (already defined at the top of `cmd/generate-cli.js`) to escape `camelCaseName` before interpolating it into the regex pattern.
- Replace the direct usage of `camelCaseName` inside the template literal with a new variable `safeCamelCaseName = escapeRegExp(camelCaseName)` and interpolate `safeCamelCaseName` instead.

Concretely:

- In `cmd/generate-cli.js`, within `findSdkTriggerSignaturesFromTemplateFile`:
  - After computing `camelCaseName`, add a line to compute `safeCamelCaseName` using `escapeRegExp(camelCaseName)`.
  - Update the `new RegExp` call to use `${safeCamelCaseName}` instead of `${camelCaseName}` in the template string.

No new imports are needed because `escapeRegExp` is already defined in this file. All other files (`price-feed-cli.js`, `automation-cli.js`, `tenderly-cli.js`, `registry-cli.js`) do not need code changes for this particular regex sink; the taint source is shared, but sanitizing at the sink in `generate-cli.js` is sufficient to resolve all the reported variants for this sink.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Escape trigger names before interpolating them into regular expression patterns used to locate SDK trigger signatures in template files, preventing potential regex injection vulnerabilities.